### PR TITLE
Fix bug preventing using different paths then /opt/venvs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ macros.
 ```
 
 # Use our interpreter for brp-python-bytecompile script
-%global __python /opt/venvs/%{name}/bin/python3
+%global __python %{__pyvenv_root}/bin/python3
 
 
 %prep
@@ -58,10 +58,10 @@ Remember to install all of the executable(s) installed under virtualenv into
 
 The following are the available macros/variables:
 
-#### %__pyvenv_root
+#### %__pyvenv\_root
 
 This points to the directory where the virtualenv has been created. Right now
-the default path is `/opt/venvs/projectname`.
+the default path is `/opt/venvs/<projectname>`.
 
 #### %__pyvenv
 

--- a/examples/ansible.spec
+++ b/examples/ansible.spec
@@ -7,7 +7,7 @@
 
 
 # Use our interpreter for brp-python-bytecompile script
-%global __python /opt/venvs/%{name}/bin/python3
+%global __python %{__pyvenv_root}/bin/python3
 
 
 

--- a/macros.python-virtualenv
+++ b/macros.python-virtualenv
@@ -1,17 +1,16 @@
-%__pyvenv %{buildroot}/opt/venvs/%{name}/bin/python3
-%__pyvenvpip3 %{buildroot}/opt/venvs/%{name}/bin/pip3
-%__pyvenv_root %{buildroot}/opt/venvs/%{name}
+%__pyvenv_root /opt/venvs/%{name}
+%__pyvenv %{buildroot}/%{__pyvenv_root}/bin/python3
+%__pyvenvpip3 %{buildroot}/%{__pyvenv_root}/bin/pip3
 
 %pyvenv_create() %{expand:\\\
-  mkdir -p %{buildroot}/opt/venvs/
+  mkdir -p %{buildroot}/%{__pyvenv_root}
   CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\\\
-  %{__python3} -m venv %{__pyvenv_root} %{?*}
+  %{__python3} -m venv %{buildroot}/%{__pyvenv_root} %{?*}
   %{__pyvenvpip3} install wheel $PYVENV_WHEEL_ARGS
   sleep 1
 }
 
 %pyvenv_build() %{expand:\\\
-  
   CFLAGS="${CFLAGS:-${RPM_OPT_FLAGS}}" LDFLAGS="${LDFLAGS:-${RPM_LD_FLAGS}}"\\\
   %{__pyvenv} %{py_setup} %{?py_setup_args} bdist_wheel %{?*}
   sleep 1
@@ -19,5 +18,5 @@
 
 %pyvenv_install() %{expand:\\\
   %{__pyvenvpip3} install -I dist/*.whl  $PYVENV_PIP_ARGS
-  find  %{__pyvenv_root} -type f -print0 | xargs -0 sed -i 's~%{buildroot}~~'
+  find %{buildroot}/%{__pyvenv_root} -type f -print0 | xargs -0 sed -i 's~%{buildroot}~~'
 }


### PR DESCRIPTION
%__pyvenv_root variable is documented as modifiable, but that wasn't
technically the case as non-/opt/venvs/%{name} directories ended up
breaking the macro.

Fix macro to support modifying %__pyvenv_root, and clarify documentation
around it's use.